### PR TITLE
Add option to manually configure bit timing

### DIFF
--- a/usbtingobus.py
+++ b/usbtingobus.py
@@ -65,6 +65,8 @@ class USBtingoBus(BusABC):
     MODE_ACTIVE = 1
     MODE_LISTENONLY = 2
 
+    MCAN_CLOCK_HZ = 120_000_000
+
     def __init__(self, channel=None, can_filters=None, **kwargs):
 
         """
@@ -104,6 +106,8 @@ class USBtingoBus(BusABC):
         self.is_fd = kwargs.get("fd", False)
         timing = kwargs.get("timing")
         if self.is_fd and isinstance(timing, BitTimingFd):
+            if timing.f_clock != self.MCAN_CLOCK_HZ:
+                timing = timing.recreate_with_f_clock(self.MCAN_CLOCK_HZ)
             self.bitrate = timing.nom_bitrate
             self.data_bitrate = timing.data_bitrate
         else:


### PR DESCRIPTION
For situations where more control over bit timing is needed, bit timing parameters can now be explicitly configured for CAN FD. This allows to e.g. configure different sample point locations.

The parameter is passed as a `can.BitTimingFd` instance, which can be created using the [`can.BitTimingFd.from_sample_point()`](https://python-can.readthedocs.io/en/stable/bit_timing.html#can.BitTimingFd.from_sample_point) or similar convenience methods.

This is inspired by the [PCAN](https://python-can.readthedocs.io/en/stable/interfaces/pcan.html) interface implementation.